### PR TITLE
feat: Phase 1.2.1 - 基本レイアウトコンポーネント作成

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,9 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
 export default function Calendar() {
   return (
-    <div className="container mx-auto px-4 py-8">
+    <MainLayout>
+      <div className="mx-auto max-w-7xl">
       <h1 className="text-3xl font-bold mb-8">📅 週間タイムブロック</h1>
 
       <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
@@ -132,5 +135,6 @@ export default function Calendar() {
         </div>
       </div>
     </div>
+    </MainLayout>
   )
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,63 +1,67 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
 export default function Dashboard() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Dashboard</h1>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-          <h2 className="text-xl font-semibold mb-4">📅 今日のカレンダー</h2>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-900/20 rounded">
-              <span>09:00 ▶ 英語学習</span>
-              <span className="text-sm text-gray-500">1時間</span>
-            </div>
-            <div className="flex items-center justify-between p-3 bg-green-50 dark:bg-green-900/20 rounded">
-              <span>10:00 開発作業</span>
-              <span className="text-sm text-gray-500">2時間</span>
-            </div>
-            <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded">
-              <span>12:00 昼食</span>
-              <span className="text-sm text-gray-500">1時間</span>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-          <h2 className="text-xl font-semibold mb-4">📝 現在のプロジェクトタスク</h2>
-          <div className="space-y-3">
-            <div className="flex items-center space-x-3">
-              <input type="checkbox" checked className="rounded" readOnly />
-              <span className="line-through text-gray-500">単語帳アプリ起動 (15分)</span>
-            </div>
-            <div className="flex items-center space-x-3">
-              <div className="w-4 h-4 bg-blue-500 rounded animate-pulse"></div>
-              <span className="font-medium">🔵 文法練習 (30分) ← 実行中</span>
-            </div>
-            <div className="flex items-center space-x-3">
-              <div className="w-4 h-4 border-2 border-gray-300 rounded"></div>
-              <span>⚪ リスニング (15分)</span>
+    <MainLayout>
+      <div className="mx-auto max-w-7xl">
+        <h1 className="text-3xl font-bold mb-8">ダッシュボード</h1>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+            <h2 className="text-xl font-semibold mb-4">📅 今日のカレンダー</h2>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-900/20 rounded">
+                <span>09:00 ▶ 英語学習</span>
+                <span className="text-sm text-gray-500">1時間</span>
+              </div>
+              <div className="flex items-center justify-between p-3 bg-green-50 dark:bg-green-900/20 rounded">
+                <span>10:00 開発作業</span>
+                <span className="text-sm text-gray-500">2時間</span>
+              </div>
+              <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded">
+                <span>12:00 昼食</span>
+                <span className="text-sm text-gray-500">1時間</span>
+              </div>
             </div>
           </div>
 
-          <div className="mt-6 p-4 bg-gray-50 dark:bg-gray-700 rounded">
-            <h3 className="font-medium mb-2">⏱️ 進行中: 文法練習</h3>
-            <div className="text-sm text-gray-600 dark:text-gray-300">
-              経過時間: 12分 / 目標30分
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+            <h2 className="text-xl font-semibold mb-4">📝 現在のプロジェクトタスク</h2>
+            <div className="space-y-3">
+              <div className="flex items-center space-x-3">
+                <input type="checkbox" checked className="rounded" readOnly />
+                <span className="line-through text-gray-500">単語帳アプリ起動 (15分)</span>
+              </div>
+              <div className="flex items-center space-x-3">
+                <div className="w-4 h-4 bg-blue-500 rounded animate-pulse"></div>
+                <span className="font-medium">🔵 文法練習 (30分) ← 実行中</span>
+              </div>
+              <div className="flex items-center space-x-3">
+                <div className="w-4 h-4 border-2 border-gray-300 rounded"></div>
+                <span>⚪ リスニング (15分)</span>
+              </div>
             </div>
-            <div className="mt-2 w-full bg-gray-200 rounded-full h-2">
-              <div className="bg-blue-600 h-2 rounded-full" style={{ width: '40%' }}></div>
-            </div>
-            <div className="text-sm text-gray-500 mt-1">進捗: 40%</div>
-          </div>
 
-          <div className="mt-6">
-            <h3 className="font-medium mb-2">📋 プロジェクトメモ</h3>
-            <div className="text-sm text-gray-600 dark:text-gray-300 space-y-1">
-              <div>- 今日は発音に重点を置く</div>
-              <div>- 次回は過去形の復習</div>
+            <div className="mt-6 p-4 bg-gray-50 dark:bg-gray-700 rounded">
+              <h3 className="font-medium mb-2">⏱️ 進行中: 文法練習</h3>
+              <div className="text-sm text-gray-600 dark:text-gray-300">
+                経過時間: 12分 / 目標30分
+              </div>
+              <div className="mt-2 w-full bg-gray-200 rounded-full h-2">
+                <div className="bg-blue-600 h-2 rounded-full" style={{ width: '40%' }}></div>
+              </div>
+              <div className="text-sm text-gray-500 mt-1">進捗: 40%</div>
+            </div>
+
+            <div className="mt-6">
+              <h3 className="font-medium mb-2">📋 プロジェクトメモ</h3>
+              <div className="text-sm text-gray-600 dark:text-gray-300 space-y-1">
+                <div>- 今日は発音に重点を置く</div>
+                <div>- 次回は過去形の復習</div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </MainLayout>
   )
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,77 +1,81 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
 export default function Projects() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">📊 プロジェクト管理</h1>
+    <MainLayout>
+      <div className="mx-auto max-w-7xl">
+        <h1 className="text-3xl font-bold mb-8">📊 プロジェクト管理</h1>
 
-      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-        <h2 className="text-xl font-semibold mb-4">📋 プロジェクト一覧</h2>
-        <div className="overflow-x-auto">
-          <table className="w-full table-auto">
-            <thead>
-              <tr className="border-b border-gray-200 dark:border-gray-700">
-                <th className="text-left py-3 px-4">プロジェクト名</th>
-                <th className="text-left py-3 px-4">週目標</th>
-                <th className="text-left py-3 px-4">実績</th>
-                <th className="text-left py-3 px-4">達成率</th>
-                <th className="text-left py-3 px-4">ステータス</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className="border-b border-gray-100 dark:border-gray-700">
-                <td className="py-3 px-4">英語能力向上</td>
-                <td className="py-3 px-4">10h</td>
-                <td className="py-3 px-4">8h</td>
-                <td className="py-3 px-4">80%</td>
-                <td className="py-3 px-4">
-                  <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-sm">
-                    🟢 順調
-                  </span>
-                </td>
-              </tr>
-              <tr className="border-b border-gray-100 dark:border-gray-700">
-                <td className="py-3 px-4">運動習慣確立</td>
-                <td className="py-3 px-4">5h</td>
-                <td className="py-3 px-4">6h</td>
-                <td className="py-3 px-4">120%</td>
-                <td className="py-3 px-4">
-                  <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-sm">
-                    🔵 超過達成
-                  </span>
-                </td>
-              </tr>
-              <tr className="border-b border-gray-100 dark:border-gray-700">
-                <td className="py-3 px-4">Web開発学習</td>
-                <td className="py-3 px-4">15h</td>
-                <td className="py-3 px-4">9h</td>
-                <td className="py-3 px-4">60%</td>
-                <td className="py-3 px-4">
-                  <span className="px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full text-sm">
-                    🟡 要調整
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td className="py-3 px-4">家族時間確保</td>
-                <td className="py-3 px-4">8h</td>
-                <td className="py-3 px-4">8h</td>
-                <td className="py-3 px-4">100%</td>
-                <td className="py-3 px-4">
-                  <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-sm">
-                    🟢 達成
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-4">📋 プロジェクト一覧</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full table-auto">
+              <thead>
+                <tr className="border-b border-gray-200 dark:border-gray-700">
+                  <th className="text-left py-3 px-4">プロジェクト名</th>
+                  <th className="text-left py-3 px-4">週目標</th>
+                  <th className="text-left py-3 px-4">実績</th>
+                  <th className="text-left py-3 px-4">達成率</th>
+                  <th className="text-left py-3 px-4">ステータス</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b border-gray-100 dark:border-gray-700">
+                  <td className="py-3 px-4">英語能力向上</td>
+                  <td className="py-3 px-4">10h</td>
+                  <td className="py-3 px-4">8h</td>
+                  <td className="py-3 px-4">80%</td>
+                  <td className="py-3 px-4">
+                    <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-sm">
+                      🟢 順調
+                    </span>
+                  </td>
+                </tr>
+                <tr className="border-b border-gray-100 dark:border-gray-700">
+                  <td className="py-3 px-4">運動習慣確立</td>
+                  <td className="py-3 px-4">5h</td>
+                  <td className="py-3 px-4">6h</td>
+                  <td className="py-3 px-4">120%</td>
+                  <td className="py-3 px-4">
+                    <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-sm">
+                      🔵 超過達成
+                    </span>
+                  </td>
+                </tr>
+                <tr className="border-b border-gray-100 dark:border-gray-700">
+                  <td className="py-3 px-4">Web開発学習</td>
+                  <td className="py-3 px-4">15h</td>
+                  <td className="py-3 px-4">9h</td>
+                  <td className="py-3 px-4">60%</td>
+                  <td className="py-3 px-4">
+                    <span className="px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full text-sm">
+                      🟡 要調整
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td className="py-3 px-4">家族時間確保</td>
+                  <td className="py-3 px-4">8h</td>
+                  <td className="py-3 px-4">8h</td>
+                  <td className="py-3 px-4">100%</td>
+                  <td className="py-3 px-4">
+                    <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-sm">
+                      🟢 達成
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
-        <div className="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-          <h3 className="font-medium mb-2">🤖 LLMインサイト</h3>
-          <p className="text-sm text-gray-700 dark:text-gray-300">
-            「Web開発の時間確保のため、明日の英語学習時間を30分短縮することを提案します」
-          </p>
+          <div className="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+            <h3 className="font-medium mb-2">🤖 LLMインサイト</h3>
+            <p className="text-sm text-gray-700 dark:text-gray-300">
+              「Web開発の時間確保のため、明日の英語学習時間を30分短縮することを提案します」
+            </p>
+          </div>
         </div>
       </div>
-    </div>
+    </MainLayout>
   )
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,9 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
 export default function Settings() {
   return (
-    <div className="container mx-auto px-4 py-8">
+    <MainLayout>
+      <div className="mx-auto max-w-7xl">
       <h1 className="text-3xl font-bold mb-8">⚙️ 設定</h1>
 
       <div className="space-y-6">
@@ -69,5 +72,6 @@ export default function Settings() {
         </div>
       </div>
     </div>
+    </MainLayout>
   )
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React from 'react'
+import { Menu, MessageCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface HeaderProps {
+  onMobileMenuClick: () => void
+  className?: string
+}
+
+export function Header({ onMobileMenuClick, className }: HeaderProps) {
+  return (
+    <header
+      className={cn(
+        'sticky top-0 z-50 flex h-14 items-center border-b bg-background px-4 md:px-6',
+        className
+      )}
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        className="md:hidden"
+        onClick={onMobileMenuClick}
+      >
+        <Menu className="h-5 w-5" />
+        <span className="sr-only">Toggle menu</span>
+      </Button>
+
+      <div className="flex items-center gap-4 md:gap-6">
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded bg-primary text-primary-foreground">
+            K
+          </div>
+          <h1 className="text-lg font-semibold">KAISHU</h1>
+        </div>
+      </div>
+
+      <div className="ml-auto flex items-center gap-4">
+        <Button variant="ghost" size="icon">
+          <MessageCircle className="h-5 w-5" />
+          <span className="sr-only">LLMチャット</span>
+        </Button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import React, { useState } from 'react'
+import { Header } from './Header'
+import { Sidebar } from './Sidebar'
+import { MobileNav } from './MobileNav'
+
+interface MainLayoutProps {
+  children: React.ReactNode
+}
+
+export function MainLayout({ children }: MainLayoutProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header onMobileMenuClick={() => setSidebarOpen(!sidebarOpen)} />
+      
+      <div className="flex h-[calc(100vh-3.5rem)]">
+        <Sidebar className="hidden md:flex" />
+        
+        <MobileNav
+          isOpen={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
+        />
+        
+        <main className="flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import React, { useEffect } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { X } from 'lucide-react'
+import {
+  LayoutDashboard,
+  FolderOpen,
+  CalendarDays,
+  Settings,
+  BarChart3,
+  CheckSquare,
+  RefreshCw,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface MobileNavProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const navigationItems = [
+  {
+    title: 'ダッシュボード',
+    href: '/dashboard',
+    icon: LayoutDashboard,
+  },
+  {
+    title: 'プロジェクト',
+    href: '/projects',
+    icon: FolderOpen,
+  },
+  {
+    title: 'カレンダー',
+    href: '/calendar',
+    icon: CalendarDays,
+  },
+  {
+    title: 'タスク',
+    href: '/tasks',
+    icon: CheckSquare,
+  },
+  {
+    title: '習慣',
+    href: '/habits',
+    icon: RefreshCw,
+  },
+  {
+    title: 'レポート',
+    href: '/reports',
+    icon: BarChart3,
+  },
+  {
+    title: '設定',
+    href: '/settings',
+    icon: Settings,
+  },
+]
+
+export function MobileNav({ isOpen, onClose }: MobileNavProps) {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'unset'
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset'
+    }
+  }, [isOpen])
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm md:hidden"
+          onClick={onClose}
+        />
+      )}
+
+      <div
+        className={cn(
+          'fixed left-0 top-0 z-50 h-full w-64 bg-background transition-transform duration-300 md:hidden',
+          isOpen ? 'translate-x-0' : '-translate-x-full'
+        )}
+      >
+        <div className="flex h-14 items-center border-b px-4">
+          <div className="flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded bg-primary text-primary-foreground">
+              K
+            </div>
+            <h1 className="text-lg font-semibold">KAISHU</h1>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="ml-auto"
+            onClick={onClose}
+          >
+            <X className="h-5 w-5" />
+            <span className="sr-only">Close menu</span>
+          </Button>
+        </div>
+
+        <nav className="flex-1 space-y-1 p-4">
+          {navigationItems.map((item) => {
+            const isActive = pathname === item.href
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={onClose}
+                className={cn(
+                  'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-secondary text-secondary-foreground'
+                    : 'text-muted-foreground hover:bg-secondary/50 hover:text-secondary-foreground'
+                )}
+              >
+                <item.icon className="h-4 w-4" />
+                {item.title}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="border-t p-4">
+          <div className="rounded-lg bg-secondary/50 p-3">
+            <p className="text-xs text-muted-foreground">
+              Version 0.1.0
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              タイムブロック確認プロトタイプ
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  LayoutDashboard,
+  FolderOpen,
+  CalendarDays,
+  Settings,
+  BarChart3,
+  CheckSquare,
+  RefreshCw,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface SidebarProps {
+  className?: string
+}
+
+const navigationItems = [
+  {
+    title: 'ダッシュボード',
+    href: '/dashboard',
+    icon: LayoutDashboard,
+  },
+  {
+    title: 'プロジェクト',
+    href: '/projects',
+    icon: FolderOpen,
+  },
+  {
+    title: 'カレンダー',
+    href: '/calendar',
+    icon: CalendarDays,
+  },
+  {
+    title: 'タスク',
+    href: '/tasks',
+    icon: CheckSquare,
+  },
+  {
+    title: '習慣',
+    href: '/habits',
+    icon: RefreshCw,
+  },
+  {
+    title: 'レポート',
+    href: '/reports',
+    icon: BarChart3,
+  },
+  {
+    title: '設定',
+    href: '/settings',
+    icon: Settings,
+  },
+]
+
+export function Sidebar({ className }: SidebarProps) {
+  const pathname = usePathname()
+
+  return (
+    <div
+      className={cn(
+        'w-64 flex-col border-r bg-background',
+        className
+      )}
+    >
+      <nav className="flex-1 space-y-1 p-4">
+        {navigationItems.map((item) => {
+          const isActive = pathname === item.href
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-secondary text-secondary-foreground'
+                  : 'text-muted-foreground hover:bg-secondary/50 hover:text-secondary-foreground'
+              )}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.title}
+            </Link>
+          )
+        })}
+      </nav>
+
+      <div className="border-t p-4">
+        <div className="rounded-lg bg-secondary/50 p-3">
+          <p className="text-xs text-muted-foreground">
+            Version 0.1.0
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            タイムブロック確認プロトタイプ
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,4 @@
+export { MainLayout } from './MainLayout'
+export { Header } from './Header'
+export { Sidebar } from './Sidebar'
+export { MobileNav } from './MobileNav'


### PR DESCRIPTION
## 概要

Phase 1.2.1に基づいて、アプリケーション全体の基本レイアウト構造を作成しました。

## 変更内容

### コンポーネント作成
- MainLayout: ヘッダー・サイドバー・メインエリアの3カラムレイアウト
- Header: ロゴ、モバイルメニュートグル、LLMチャットボタン
- Sidebar: ナビゲーションメニューとバージョン表示
- MobileNav: モバイル用ドロワーナビゲーション

### ページ更新
- Dashboard、Projects、Calendar、SettingsページにMainLayoutを適用

## 受け入れ条件の達成
- ✅ ヘッダー・サイドバー・メインエリアの3カラムレイアウト
- ✅ モバイル対応（ハンバーガーメニュー）
- ✅ shadcn/uiコンポーネントを活用
- ✅ 各画面で再利用可能な構造

Closes #4

Generated with [Claude Code](https://claude.ai/code)