### PR TITLE
feat: implement project list display components

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,80 +1,99 @@
+'use client'
+
 import { MainLayout } from '@/components/layout/MainLayout'
+import { ProjectList } from '@/components/projects'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const mockProjects = [
+  {
+    id: '1',
+    name: '英語能力向上',
+    type: 'learning' as const,
+    status: 'active' as const,
+    weeklyTargetHours: 10,
+    weeklyActualHours: 8,
+    progressRate: 80,
+    lastUpdated: new Date('2024-06-01'),
+  },
+  {
+    id: '2',
+    name: '運動習慣確立',
+    type: 'health' as const,
+    status: 'active' as const,
+    weeklyTargetHours: 5,
+    weeklyActualHours: 6,
+    progressRate: 120,
+    lastUpdated: new Date('2024-06-02'),
+  },
+  {
+    id: '3',
+    name: 'Web開発学習',
+    type: 'learning' as const,
+    status: 'active' as const,
+    weeklyTargetHours: 15,
+    weeklyActualHours: 9,
+    progressRate: 60,
+    lastUpdated: new Date('2024-05-30'),
+  },
+  {
+    id: '4',
+    name: '家族時間確保',
+    type: 'relationship' as const,
+    status: 'active' as const,
+    weeklyTargetHours: 8,
+    weeklyActualHours: 8,
+    progressRate: 100,
+    lastUpdated: new Date('2024-06-02'),
+  },
+  {
+    id: '5',
+    name: '読書習慣',
+    type: 'hobby' as const,
+    status: 'paused' as const,
+    weeklyTargetHours: 5,
+    weeklyActualHours: 2,
+    progressRate: 40,
+    lastUpdated: new Date('2024-05-25'),
+  },
+  {
+    id: '6',
+    name: '副業プロジェクト',
+    type: 'work' as const,
+    status: 'planned' as const,
+    weeklyTargetHours: 10,
+    weeklyActualHours: 0,
+    progressRate: 0,
+    lastUpdated: new Date('2024-05-20'),
+  },
+]
 
 export default function Projects() {
   return (
     <MainLayout>
-      <div className="mx-auto max-w-7xl">
-        <h1 className="text-3xl font-bold mb-8">📊 プロジェクト管理</h1>
-
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-          <h2 className="text-xl font-semibold mb-4">📋 プロジェクト一覧</h2>
-          <div className="overflow-x-auto">
-            <table className="w-full table-auto">
-              <thead>
-                <tr className="border-b border-gray-200 dark:border-gray-700">
-                  <th className="text-left py-3 px-4">プロジェクト名</th>
-                  <th className="text-left py-3 px-4">週目標</th>
-                  <th className="text-left py-3 px-4">実績</th>
-                  <th className="text-left py-3 px-4">達成率</th>
-                  <th className="text-left py-3 px-4">ステータス</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr className="border-b border-gray-100 dark:border-gray-700">
-                  <td className="py-3 px-4">英語能力向上</td>
-                  <td className="py-3 px-4">10h</td>
-                  <td className="py-3 px-4">8h</td>
-                  <td className="py-3 px-4">80%</td>
-                  <td className="py-3 px-4">
-                    <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-sm">
-                      🟢 順調
-                    </span>
-                  </td>
-                </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-700">
-                  <td className="py-3 px-4">運動習慣確立</td>
-                  <td className="py-3 px-4">5h</td>
-                  <td className="py-3 px-4">6h</td>
-                  <td className="py-3 px-4">120%</td>
-                  <td className="py-3 px-4">
-                    <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-sm">
-                      🔵 超過達成
-                    </span>
-                  </td>
-                </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-700">
-                  <td className="py-3 px-4">Web開発学習</td>
-                  <td className="py-3 px-4">15h</td>
-                  <td className="py-3 px-4">9h</td>
-                  <td className="py-3 px-4">60%</td>
-                  <td className="py-3 px-4">
-                    <span className="px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full text-sm">
-                      🟡 要調整
-                    </span>
-                  </td>
-                </tr>
-                <tr>
-                  <td className="py-3 px-4">家族時間確保</td>
-                  <td className="py-3 px-4">8h</td>
-                  <td className="py-3 px-4">8h</td>
-                  <td className="py-3 px-4">100%</td>
-                  <td className="py-3 px-4">
-                    <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-sm">
-                      🟢 達成
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div className="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-            <h3 className="font-medium mb-2">🤖 LLMインサイト</h3>
-            <p className="text-sm text-gray-700 dark:text-gray-300">
-              「Web開発の時間確保のため、明日の英語学習時間を30分短縮することを提案します」
-            </p>
-          </div>
+      <div className="mx-auto max-w-7xl space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">📊 プロジェクト管理</h1>
+          <p className="text-muted-foreground">
+            人生目標達成のためのプロジェクトを管理します
+          </p>
         </div>
+
+        <ProjectList projects={mockProjects} />
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span>🤖</span>
+              LLMインサイト
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              「Web開発の時間確保のため、明日の英語学習時間を30分短縮することを提案します。
+              運動習慣は良好に維持されているので、このペースを継続してください。」
+            </p>
+          </CardContent>
+        </Card>
       </div>
     </MainLayout>
   )

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import * as React from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import { Calendar, Clock, Target, TrendingUp } from 'lucide-react'
+import { ProjectProgress } from './ProjectProgress'
+
+export interface ProjectCardProps {
+  className?: string
+  project: {
+    id: string
+    name: string
+    type: 'learning' | 'health' | 'work' | 'hobby' | 'relationship' | 'other'
+    status: 'active' | 'paused' | 'planned' | 'completed' | 'cancelled'
+    weeklyTargetHours: number
+    weeklyActualHours: number
+    progressRate: number
+    lastUpdated: Date
+  }
+  variant?: 'grid' | 'list'
+}
+
+const statusColors = {
+  active: 'border-green-500 dark:border-green-400',
+  paused: 'border-yellow-500 dark:border-yellow-400',
+  planned: 'border-gray-500 dark:border-gray-400',
+  completed: 'border-blue-500 dark:border-blue-400',
+  cancelled: 'border-red-500 dark:border-red-400',
+}
+
+const statusEmojis = {
+  active: '🟢',
+  paused: '🟡',
+  planned: '⚪',
+  completed: '🔵',
+  cancelled: '🔴',
+}
+
+const typeIcons = {
+  learning: '📚',
+  health: '💪',
+  work: '💼',
+  hobby: '🎨',
+  relationship: '👥',
+  other: '📌',
+}
+
+export function ProjectCard({ className, project, variant = 'grid' }: ProjectCardProps) {
+  const isOnTrack = project.weeklyActualHours >= project.weeklyTargetHours * 0.8
+
+  if (variant === 'list') {
+    return (
+      <Card className={cn('transition-all hover:shadow-md', statusColors[project.status], className)}>
+        <CardContent className="flex items-center justify-between p-4">
+          <div className="flex items-center gap-4">
+            <span className="text-2xl">{typeIcons[project.type]}</span>
+            <div>
+              <h3 className="font-semibold flex items-center gap-2">
+                {project.name}
+                <span>{statusEmojis[project.status]}</span>
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                最終更新: {project.lastUpdated.toLocaleDateString('ja-JP')}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-6">
+            <div className="text-right">
+              <p className="text-sm text-muted-foreground">週目標 / 実績</p>
+              <p className="font-semibold">
+                {project.weeklyTargetHours}h / {project.weeklyActualHours}h
+              </p>
+            </div>
+            <ProjectProgress progress={project.progressRate} size="sm" />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className={cn('transition-all hover:shadow-md border-2', statusColors[project.status], className)}>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <span className="text-xl">{typeIcons[project.type]}</span>
+            {project.name}
+          </span>
+          <span>{statusEmojis[project.status]}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div className="flex items-center gap-2">
+            <Target className="h-4 w-4 text-muted-foreground" />
+            <span>週目標: {project.weeklyTargetHours}h</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4 text-muted-foreground" />
+            <span>実績: {project.weeklyActualHours}h</span>
+          </div>
+        </div>
+        
+        <ProjectProgress progress={project.progressRate} showLabel />
+        
+        <div className="flex items-center justify-between text-sm">
+          <div className="flex items-center gap-2">
+            <TrendingUp className={cn('h-4 w-4', isOnTrack ? 'text-green-500' : 'text-yellow-500')} />
+            <span className={isOnTrack ? 'text-green-600 dark:text-green-400' : 'text-yellow-600 dark:text-yellow-400'}>
+              {isOnTrack ? '順調' : '要調整'}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Calendar className="h-4 w-4" />
+            <span>{project.lastUpdated.toLocaleDateString('ja-JP')}</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/projects/ProjectFilters.tsx
+++ b/src/components/projects/ProjectFilters.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import * as React from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { Filter, Grid, List, Search, SortAsc } from 'lucide-react'
+
+export interface ProjectFiltersProps {
+  className?: string
+  viewMode: 'grid' | 'list'
+  onViewModeChange: (mode: 'grid' | 'list') => void
+  onFilterChange: (filter: ProjectFilter) => void
+  onSortChange: (sort: ProjectSort) => void
+  onSearchChange: (search: string) => void
+}
+
+export interface ProjectFilter {
+  status?: ('active' | 'paused' | 'planned' | 'completed' | 'cancelled')[]
+  type?: ('learning' | 'health' | 'work' | 'hobby' | 'relationship' | 'other')[]
+}
+
+export interface ProjectSort {
+  field: 'name' | 'progress' | 'lastUpdated' | 'weeklyHours'
+  direction: 'asc' | 'desc'
+}
+
+const statusOptions = [
+  { value: 'active', label: '実行中', emoji: '🟢' },
+  { value: 'paused', label: '一時停止', emoji: '🟡' },
+  { value: 'planned', label: '計画中', emoji: '⚪' },
+  { value: 'completed', label: '完了', emoji: '🔵' },
+  { value: 'cancelled', label: 'キャンセル', emoji: '🔴' },
+]
+
+const typeOptions = [
+  { value: 'learning', label: '学習', emoji: '📚' },
+  { value: 'health', label: '健康', emoji: '💪' },
+  { value: 'work', label: '仕事', emoji: '💼' },
+  { value: 'hobby', label: '趣味', emoji: '🎨' },
+  { value: 'relationship', label: '人間関係', emoji: '👥' },
+  { value: 'other', label: 'その他', emoji: '📌' },
+]
+
+const sortOptions = [
+  { value: 'name', label: 'プロジェクト名' },
+  { value: 'progress', label: '進捗率' },
+  { value: 'lastUpdated', label: '最終更新日' },
+  { value: 'weeklyHours', label: '週時間' },
+]
+
+export function ProjectFilters({
+  className,
+  viewMode,
+  onViewModeChange,
+  onFilterChange,
+  onSortChange,
+  onSearchChange,
+}: ProjectFiltersProps) {
+  const [selectedStatuses, setSelectedStatuses] = React.useState<string[]>([])
+  const [selectedTypes, setSelectedTypes] = React.useState<string[]>([])
+  const [sortField, setSortField] = React.useState<ProjectSort['field']>('lastUpdated')
+  const [sortDirection, setSortDirection] = React.useState<ProjectSort['direction']>('desc')
+
+  const handleStatusToggle = (status: string) => {
+    const newStatuses = selectedStatuses.includes(status)
+      ? selectedStatuses.filter(s => s !== status)
+      : [...selectedStatuses, status]
+    setSelectedStatuses(newStatuses)
+    onFilterChange({ status: newStatuses as any[], type: selectedTypes as any[] })
+  }
+
+  const handleTypeToggle = (type: string) => {
+    const newTypes = selectedTypes.includes(type)
+      ? selectedTypes.filter(t => t !== type)
+      : [...selectedTypes, type]
+    setSelectedTypes(newTypes)
+    onFilterChange({ status: selectedStatuses as any[], type: newTypes as any[] })
+  }
+
+  const handleSortChange = (field: ProjectSort['field']) => {
+    const newDirection = field === sortField && sortDirection === 'asc' ? 'desc' : 'asc'
+    setSortField(field)
+    setSortDirection(newDirection)
+    onSortChange({ field, direction: newDirection })
+  }
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+      <div className="flex-1 max-w-sm">
+        <div className="relative">
+          <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="プロジェクトを検索..."
+            className="pl-8"
+            onChange={(e) => onSearchChange(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            <Filter className="mr-2 h-4 w-4" />
+            フィルター
+            {(selectedStatuses.length > 0 || selectedTypes.length > 0) && (
+              <span className="ml-1 rounded-full bg-primary px-1.5 py-0.5 text-xs text-primary-foreground">
+                {selectedStatuses.length + selectedTypes.length}
+              </span>
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuLabel>ステータス</DropdownMenuLabel>
+          {statusOptions.map((option) => (
+            <DropdownMenuItem
+              key={option.value}
+              onSelect={(e) => {
+                e.preventDefault()
+                handleStatusToggle(option.value)
+              }}
+            >
+              <span className="mr-2">{option.emoji}</span>
+              {option.label}
+              {selectedStatuses.includes(option.value) && (
+                <span className="ml-auto">✓</span>
+              )}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>タイプ</DropdownMenuLabel>
+          {typeOptions.map((option) => (
+            <DropdownMenuItem
+              key={option.value}
+              onSelect={(e) => {
+                e.preventDefault()
+                handleTypeToggle(option.value)
+              }}
+            >
+              <span className="mr-2">{option.emoji}</span>
+              {option.label}
+              {selectedTypes.includes(option.value) && (
+                <span className="ml-auto">✓</span>
+              )}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            <SortAsc className="mr-2 h-4 w-4" />
+            並び替え
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {sortOptions.map((option) => (
+            <DropdownMenuItem
+              key={option.value}
+              onSelect={() => handleSortChange(option.value as ProjectSort['field'])}
+            >
+              {option.label}
+              {sortField === option.value && (
+                <span className="ml-auto">
+                  {sortDirection === 'asc' ? '↑' : '↓'}
+                </span>
+              )}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <div className="flex items-center rounded-lg border">
+        <Button
+          variant={viewMode === 'grid' ? 'default' : 'ghost'}
+          size="sm"
+          className="rounded-r-none"
+          onClick={() => onViewModeChange('grid')}
+        >
+          <Grid className="h-4 w-4" />
+        </Button>
+        <Button
+          variant={viewMode === 'list' ? 'default' : 'ghost'}
+          size="sm"
+          className="rounded-l-none"
+          onClick={() => onViewModeChange('list')}
+        >
+          <List className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/projects/ProjectList.tsx
+++ b/src/components/projects/ProjectList.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import { ProjectCard } from './ProjectCard'
+import { ProjectFilters, ProjectFilter, ProjectSort } from './ProjectFilters'
+
+export interface ProjectListProps {
+  className?: string
+  projects: {
+    id: string
+    name: string
+    type: 'learning' | 'health' | 'work' | 'hobby' | 'relationship' | 'other'
+    status: 'active' | 'paused' | 'planned' | 'completed' | 'cancelled'
+    weeklyTargetHours: number
+    weeklyActualHours: number
+    progressRate: number
+    lastUpdated: Date
+  }[]
+}
+
+export function ProjectList({ className, projects }: ProjectListProps) {
+  const [viewMode, setViewMode] = React.useState<'grid' | 'list'>('grid')
+  const [searchQuery, setSearchQuery] = React.useState('')
+  const [filter, setFilter] = React.useState<ProjectFilter>({})
+  const [sort, setSort] = React.useState<ProjectSort>({ 
+    field: 'lastUpdated', 
+    direction: 'desc' 
+  })
+
+  const filteredAndSortedProjects = React.useMemo(() => {
+    let filtered = [...projects]
+
+    // Apply search filter
+    if (searchQuery) {
+      filtered = filtered.filter(project =>
+        project.name.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    }
+
+    // Apply status filter
+    if (filter.status && filter.status.length > 0) {
+      filtered = filtered.filter(project =>
+        filter.status!.includes(project.status)
+      )
+    }
+
+    // Apply type filter
+    if (filter.type && filter.type.length > 0) {
+      filtered = filtered.filter(project =>
+        filter.type!.includes(project.type)
+      )
+    }
+
+    // Apply sorting
+    filtered.sort((a, b) => {
+      let aValue: any, bValue: any
+
+      switch (sort.field) {
+        case 'name':
+          aValue = a.name
+          bValue = b.name
+          break
+        case 'progress':
+          aValue = a.progressRate
+          bValue = b.progressRate
+          break
+        case 'lastUpdated':
+          aValue = a.lastUpdated.getTime()
+          bValue = b.lastUpdated.getTime()
+          break
+        case 'weeklyHours':
+          aValue = a.weeklyActualHours
+          bValue = b.weeklyActualHours
+          break
+      }
+
+      if (typeof aValue === 'string') {
+        return sort.direction === 'asc' 
+          ? aValue.localeCompare(bValue) 
+          : bValue.localeCompare(aValue)
+      }
+
+      return sort.direction === 'asc' 
+        ? aValue - bValue 
+        : bValue - aValue
+    })
+
+    return filtered
+  }, [projects, searchQuery, filter, sort])
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <ProjectFilters
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        onFilterChange={setFilter}
+        onSortChange={setSort}
+        onSearchChange={setSearchQuery}
+      />
+
+      {filteredAndSortedProjects.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground">
+            {searchQuery || filter.status?.length || filter.type?.length
+              ? '該当するプロジェクトが見つかりません'
+              : 'プロジェクトがありません'}
+          </p>
+        </div>
+      ) : viewMode === 'grid' ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredAndSortedProjects.map((project) => (
+            <ProjectCard key={project.id} project={project} variant="grid" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filteredAndSortedProjects.map((project) => (
+            <ProjectCard key={project.id} project={project} variant="list" />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/projects/ProjectProgress.tsx
+++ b/src/components/projects/ProjectProgress.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ProjectProgressProps {
+  className?: string
+  progress: number
+  size?: 'sm' | 'md' | 'lg'
+  showLabel?: boolean
+  barColor?: string
+}
+
+const sizeClasses = {
+  sm: 'h-2',
+  md: 'h-3',
+  lg: 'h-4',
+}
+
+export function ProjectProgress({ 
+  className, 
+  progress, 
+  size = 'md', 
+  showLabel = false,
+  barColor
+}: ProjectProgressProps) {
+  const clampedProgress = Math.min(Math.max(progress, 0), 100)
+  
+  const getProgressColor = () => {
+    if (barColor) return barColor
+    if (clampedProgress >= 100) return 'bg-blue-500 dark:bg-blue-400'
+    if (clampedProgress >= 80) return 'bg-green-500 dark:bg-green-400'
+    if (clampedProgress >= 50) return 'bg-yellow-500 dark:bg-yellow-400'
+    return 'bg-red-500 dark:bg-red-400'
+  }
+
+  return (
+    <div className={cn('space-y-1', className)}>
+      {showLabel && (
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">進捗率</span>
+          <span className="font-medium">{clampedProgress}%</span>
+        </div>
+      )}
+      <div 
+        className={cn(
+          'w-full bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden',
+          sizeClasses[size]
+        )}
+      >
+        <div
+          className={cn(
+            'h-full transition-all duration-300 ease-out rounded-full',
+            getProgressColor()
+          )}
+          style={{ width: `${clampedProgress}%` }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/projects/index.ts
+++ b/src/components/projects/index.ts
@@ -1,0 +1,9 @@
+export { ProjectList } from './ProjectList'
+export { ProjectCard } from './ProjectCard'
+export { ProjectProgress } from './ProjectProgress'
+export { ProjectFilters } from './ProjectFilters'
+
+export type { ProjectListProps } from './ProjectList'
+export type { ProjectCardProps } from './ProjectCard'
+export type { ProjectProgressProps } from './ProjectProgress'
+export type { ProjectFiltersProps, ProjectFilter, ProjectSort } from './ProjectFilters'


### PR DESCRIPTION
Closes #8

## 概要
プロジェクト管理画面で使用する一覧表示コンポーネントを実装しました。

## 実装内容
- ProjectCardコンポーネント（グリッド/リスト表示対応）
- ProjectProgressコンポーネント（進捗率の可視化）
- ProjectFiltersコンポーネント（検索・フィルター・ソート機能）
- ProjectListコンポーネント（コンテナコンポーネント）
- プロジェクトページの更新

## 受け入れ条件
- ✅ プロジェクト名・タイプ・進捗率が表示される
- ✅ 週目標時間 vs 実績時間の比較表示
- ✅ ステータス別の色分け表示
- ✅ グリッド・リスト表示の切り替え

Generated with [Claude Code](https://claude.ai/code)